### PR TITLE
fix to 17146

### DIFF
--- a/build/transforms/writeAmd.js
+++ b/build/transforms/writeAmd.js
@@ -340,7 +340,7 @@ define([
 			}else{
 				text = insertAbsMid(resource.getText(), resource);
 				if(bc.internStrings){
-					text += getStrings(resource);
+					text = getStrings(resource) + text;
 				}
 			}
 


### PR DESCRIPTION
Write string cache entries before module definition when interning strings as required by some IE loader paths. This fix only affects non-layer resources since layer resources appear to be expressed correctly.
