### PR TITLE
Make DOH more friendly to other AMD loaders:

### DIFF
--- a/doh/_parseURLargs.js
+++ b/doh/_parseURLargs.js
@@ -176,8 +176,20 @@
 		};
 	}else{
 		config= {
+			// override non-standard behavior of V1 dojo.js, which set baseUrl to dojo dir
+			baseUrl: "../..",
+			tlmSiblingOfDojo: false,
+
 			paths: paths,
-			deps: ["dojo/domReady", "doh"],
+			packages: [
+				{ name: 'doh', location: 'util/doh' },
+
+				// override non-standard behavior of V1 dojo.js which remaps these packages
+				'dojo',
+				'dijit',
+				'dojox'
+			],
+			deps: ["dojo/domReady", "doh/main"],
 			callback: function(domReady, doh){
 				domReady(function(){
 					doh._fixHeight();


### PR DESCRIPTION
- specify baseUrl explicitly
- specify mapping from doh --> util/doh explicitly
- don't depend on mapping from doh to doh/main
- use tlmSiblingOfDojo etc. to make things still work with dojo V1 loader
