### PR TITLE
Add support for a new build option: useSourceMaps

### DIFF
--- a/build/buildControl.js
+++ b/build/buildControl.js
@@ -581,7 +581,8 @@ define([
 				startTimestamp:1,
 				staticHasFeatures:1,
 				stripConsole:1,
-				trees:1
+				trees:1,
+				useSourceMaps:1
 			};
 			for(var p in toDump){
 				toDump[p] = bc[p];

--- a/build/buildControlDefault.js
+++ b/build/buildControlDefault.js
@@ -7,6 +7,7 @@ define([
 		internSkipList:[],
 		optimize:"",
 		layerOptimize:"shrinksafe",
+		useSourceMaps:1,
 		cssOptimize:"",
 		cssImportIgnore:"",
 		stripConsole:"normal",

--- a/build/help.txt
+++ b/build/help.txt
@@ -74,11 +74,15 @@ OPTIONS
 
      --optimize <arg>          analogous to --layerOptimize, but applied to non-layer resources
 
+     --useSourceMaps <arg>     create source maps when the Google Closure compiler is used; arg as follows:
+                                   true  => create source maps (default)
+                                   false => don't create source maps
+
      --copyTests <arg>         copy test files and the DOH package; arg as follows:
                                    false => don't copy tests
                                    true  => copy test resources, but don't apply any transforms
                                    build => copy and build tests resources just as if they were normal resources
-     
+
      --mini                    Ignore resources tagged as not mini (e.g. tests, demos dijit/bench, etc.)
      
      -v                        print the program's version number

--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -84,7 +84,7 @@ function sscompile(src, dest, optimizeSwitch, copyright){
 }
 
 var JSSourceFilefromCode, closurefromCode, jscomp = 0;
-function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions){
+function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSourceMaps){
 	if(!jscomp){
 		JSSourceFilefromCode=java.lang.Class.forName("com.google.javascript.jscomp.JSSourceFile").getMethod("fromCode", [java.lang.String, java.lang.String]);
 		closurefromCode = function(filename,content){
@@ -123,16 +123,18 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions){
 
 	// Run the compiler
 	// File name and associated map name
-	var map_tag = "//@ sourceMappingURL=" + destFilename + ".map",
+	var map_tag = useSourceMaps ? "\n//@ sourceMappingURL=" + destFilename + ".map" : "",
 		compiler = new Packages.com.google.javascript.jscomp.Compiler(Packages.java.lang.System.err);
 	compiler.compile(externSourceFile, jsSourceFile, options);
-	writeFile(dest, copyright + built + compiler.toSource() + "\n" + map_tag, "utf-8");
+	writeFile(dest, copyright + built + compiler.toSource() + map_tag, "utf-8");
 
-	var sourceMap = compiler.getSourceMap();
-	sourceMap.setWrapperPrefix(copyright + "//>>built");
-	var sb = new java.lang.StringBuffer();
-	sourceMap.appendTo(sb, destFilename);
-	writeFile(dest + ".map", sb.toString(), "utf-8");
+	if(useSourceMaps){
+		var sourceMap = compiler.getSourceMap();
+		sourceMap.setWrapperPrefix(copyright + "//>>built");
+		var sb = new java.lang.StringBuffer();
+		sourceMap.appendTo(sb, destFilename);
+		writeFile(dest + ".map", sb.toString(), "utf-8");
+	}
 }
 
 
@@ -159,7 +161,7 @@ while(1){
 		exception = "";
 	try{
 		if(/closure/.test(optimizeSwitch)){
-			ccompile(src, dest, optimizeSwitch, options.copyright, options.options);
+			ccompile(src, dest, optimizeSwitch, options.copyright, options.options, options.useSourceMaps);
 		}else{
 			sscompile(src, dest, optimizeSwitch, options.copyright);
 		}

--- a/build/transforms/optimizer/sendJob.js
+++ b/build/transforms/optimizer/sendJob.js
@@ -95,7 +95,7 @@ define([
 					sent:[],
 					write:function(src, dest, optimizeSwitch, copyright){
 						proc.sent.push(dest);
-						runner.stdin.write(src + "\n" + dest + "\n" + optimizeSwitch + "\n" + JSON.stringify({ copyright: copyright, options: bc.optimizeOptions }) + "\n");
+						runner.stdin.write(src + "\n" + dest + "\n" + optimizeSwitch + "\n" + JSON.stringify({ copyright: copyright, options: bc.optimizeOptions, useSourceMaps: bc.useSourceMaps }) + "\n");
 					},
 					sink:function(output){
 						proc.tempResults += output;


### PR DESCRIPTION
This update adds support for a new boolean build option named `useSourceMaps`. It is applied when the Google Closure Compiler is enabled via the `layerOptimize` option.
- **true** - This is the default value.  Source maps will be generated.
- **false** - Source maps will not be created.

Dojo toolkit ticket: https://bugs.dojotoolkit.org/ticket/17425
