### PR TITLE
Proposed fix for trac ticket #17155

### DIFF
--- a/build/transforms/writeAmd.js
+++ b/build/transforms/writeAmd.js
@@ -197,22 +197,20 @@ define([
 				getAllAvailableLocales = function(){
 					var set = {},
 						table = [],
+						addLocale = function(loc){
+							if(!set[loc]){
+								table.push(loc);
+								set[loc] = 1;
+							}
+						},
 						readBundle = function(bundle){
 							for(var p in bundle.localizedSet){
-								if(!set[p]){
-									table.push(p);
-									set[p] = 1;
-								}
+								addLocale(p);	
 							}
 						};
 						
 					rootBundles.forEach(readBundle);
-					getFlattenedLocales().forEach(function(p){
-						if(!set[p]){
-							table.push(p);
-							set[p] = 1;
-						}
-					});
+					getFlattenedLocales().forEach(addLocale);
 						
 					return table;
 				},


### PR DESCRIPTION
This is a two parts fix, one in dojo/i18n, one in util/build/tranforms/writeAMD.

The idea is to gather a list of all available locales in the application at build time, so the i18n plugin can decide of the best available locale without doing any http request.

There is two other pull requests for 1.8 branch to account for the different code base.
