### PR TITLE
Refs DTK ticket 17243, update the CSS optimizer to end a URL path at a hash tag as well as a question mark

### DIFF
--- a/build/transforms/optimizeCss.js
+++ b/build/transforms/optimizeCss.js
@@ -138,7 +138,7 @@ define([
 				return importContents.replace(cssUrlRegExp, function(fullMatch, urlMatch){
 					var fixedUrl = checkSlashes(cleanCssUrlQuotes(urlMatch)),
 						queryString = "",
-						queryStart = fixedUrl.indexOf("?");
+						queryStart = fixedUrl.search(/\?|#/);
 					if(queryStart > 0){
 						queryString = fixedUrl.slice(queryStart);
 						fixedUrl = fixedUrl.slice(0, queryStart);


### PR DESCRIPTION
DTK ticket: https://bugs.dojotoolkit.org/ticket/17243

This change conforms to the URI spec: http://tools.ietf.org/html/rfc3986#section-3.3

> The path is terminated by the first question mark ("?") or number sign ("#") character, or by the end of the URI.
