### PR TITLE
account for newline in sourcemap prefix

### DIFF
--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -129,7 +129,7 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions){
 	writeFile(dest, copyright + built + compiler.toSource() + "\n" + map_tag, "utf-8");
 
 	var sourceMap = compiler.getSourceMap();
-	sourceMap.setWrapperPrefix(copyright + "//>>built");
+	sourceMap.setWrapperPrefix(copyright + built);
 	var sb = new java.lang.StringBuffer();
 	sourceMap.appendTo(sb, destFilename);
 	writeFile(dest + ".map", sb.toString(), "utf-8");

--- a/build/transforms/optimizer/closure.js
+++ b/build/transforms/optimizer/closure.js
@@ -30,7 +30,8 @@ define([
 	if(has("host-rhino")){
 		var JSSourceFilefromCode,
 			closurefromCode,
-			jscomp = 0;
+			jscomp = 0,
+			built = "//>>built" + bc.newline;
 
 		var ccompile = function(text, dest, optimizeSwitch, copyright){
 			/*jshint rhino:true */
@@ -71,10 +72,10 @@ define([
 			var map_tag = "//@ sourceMappingURL=" + destFilename + ".map";
             var compiler = new Packages.com.google.javascript.jscomp.Compiler(Packages.java.lang.System.err);
             compiler.compile(externSourceFile, jsSourceFile, options);
-            var result = copyright + "//>>built" + bc.newline + compiler.toSource() + bc.newline + map_tag;
+            var result = copyright + built + compiler.toSource() + bc.newline + map_tag;
 
 			var sourceMap = compiler.getSourceMap();
-			sourceMap.setWrapperPrefix(copyright + "//>>built");
+			sourceMap.setWrapperPrefix(copyright + built);
 			var sb = new java.lang.StringBuffer();
 			sourceMap.appendTo(sb, destFilename);
 			fs.writeFile(dest + ".map", sb.toString(), "utf-8");


### PR DESCRIPTION
sourcemaps are broken because they don't account for the newline after the "//>>built" pragma
