### PR TITLE
fix #17429 optimizeCss can produce invalid CSS for unresolved @imports

### DIFF
--- a/build/messages.js
+++ b/build/messages.js
@@ -53,6 +53,7 @@ define([], function(){
 		[1, 225, "missingDirDuringDiscovery", "A directory that was scheduled to be read during discovery did not exist."],
 		[1, 226, "missingProfile", "A package without a profile could throw errors or warnings."],
 		[1, 227, "symbolsLeak", "Inserting symbols (by setting the profile variable 'symbol') causes leaks in IE."],
+		[1, 228, "cssOptimizeIgnoredNoResource", "While optimizing a CSS file, an import directive was not expanded because the source for the import was not available to the builder."],
 
 		// error 300-399
 		[1, 300, "dojoHasMissingPlugin", "Missing dojo/has module."],
@@ -115,7 +116,6 @@ define([], function(){
 		[1, 356, "optimizeFailed", "The optimizer threw an exception; the module probably contains syntax errors."],
 		[1, 357, "cssOptimizeUnableToResolveURL", "While optimizing a CSS file, it was impossible to compute the destination location of a relative URL."],
 		[1, 358, "cssOptimizeImproperComment", "While optimizing a CSS file, an improper comment was encountered."],
-		[1, 359, "cssOptimizeIgnoredNoResource", "While optimizing a CSS file, an import directive was not expanded because the source for the import was not available to the builder."],
 
 		// reports 400-499
 		[1, 400, "hasReport", "Has Features Detected"],

--- a/build/transforms/optimizeCss.js
+++ b/build/transforms/optimizeCss.js
@@ -87,7 +87,8 @@ define([
 			var dest = resource.dest,
 				src = resource.src,
 				srcReferencePath = fileUtils.getFilepath(checkSlashes(src)),
-				text = resource.text;
+				text = resource.text,
+				imports = [];
 			text = text.replace(/^\uFEFF/, ''); // remove BOM
 			text = removeComments(text, src);
 			text = text.replace(cssImportRegExp, function(fullMatch, urlStart, importUrl, urlEnd, mediaTypes){
@@ -157,6 +158,16 @@ define([
 					return fullMatch;
 				});
 			});
+
+			//Hoist imports to maintain valid CSS
+			text = text.replace(cssImportRegExp, function(fullMatch){
+				imports.push(fullMatch);
+				return "";
+			});
+
+			if(imports.length) {
+				text = imports.join("\n") + "\n" + text;
+			}
 
 			if(/keepLines/i.test(bc.cssOptimize)){
 				// remove multiple empty lines.


### PR DESCRIPTION
- Updated optimizeCSS transform to hoist imports.
- Change unresolved imports from an error to a warning.
