### PR TITLE
refs #17809, Fix Dojo build

### DIFF
--- a/build/transforms/optimizer/closure.js
+++ b/build/transforms/optimizer/closure.js
@@ -37,7 +37,7 @@ define([
 			/*jshint rhino:true */
 			/*global com:false Packages:false */
 			if(!jscomp){
-				JSSourceFilefromCode = java.lang.Class.forName("com.google.javascript.jscomp.JSSourceFile").getMethod("fromCode", [ java.lang.String, java.lang.String ]);
+				JSSourceFilefromCode = java.lang.Class.forName("com.google.javascript.jscomp.SourceFile").getMethod("fromCode", [ java.lang.String, java.lang.String ]);
 				closurefromCode = function(filename,content){
 					return JSSourceFilefromCode.invoke(null, [filename, content]);
 				};


### PR DESCRIPTION
Fix #17809: Dojo build doesn't work with the latest Closure Compiler

Use com.google.javascript.jscomp.SourceFile instead of deprecated (and
deleted) com.google.javascript.jscomp.JSSourceFile
