### PR TITLE
Update stripConsole to support window.console

### DIFF
--- a/build/transforms/optimizer/stripConsole.js
+++ b/build/transforms/optimizer/stripConsole.js
@@ -6,9 +6,10 @@ define(["../../buildControl"], function(bc){
 		}else if(bc.stripConsole === "all"){
 			consoleMethods += "|warn|error";
 		}
+		// Match on "window.console" and plain "console" but not things like "myconsole" or "my.console"
 		var stripConsoleRe = new RegExp("([^\\w\\.]|^)((window.)?console\\.(" + consoleMethods + ")\\s*\\()", "g");
 		return function(text){
-			return text.replace(stripConsoleRe, "$10 && $2");
+			return text.replace(stripConsoleRe, "$1 0 && $2");
 		};
 	}else{
 		return function(text){


### PR DESCRIPTION
This update accommodates `window.console` and it will avoid modifying `myconsole.log` or `my.console.log`.

Fix for ticket #18025: https://bugs.dojotoolkit.org/ticket/18025
