### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "less"]
 	path = less
-	url = git://github.com/cloudhead/less.js.git
+	url = https://github.com/less/less.js.git


### PR DESCRIPTION
Change less url to use https and current location.

This fixes the problem where ssh is blocked by some firewalls and makes it consistent with:
https://github.com/dojo/dojox/blob/master/.gitmodules
