### PR TITLE
fixes #17105, Prevent 60s closure compiler timeout

### DIFF
--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -137,6 +137,20 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 	}
 }
 
+function shutdownClosureExecutorService(){
+	try{
+		var compilerClass = java.lang.Class.forName("com.google.javascript.jscomp.Compiler");
+		var compilerExecutorField = compilerClass.getDeclaredField("compilerExecutor");
+		compilerExecutorField.setAccessible(true);
+		var compilerExecutor = compilerExecutorField.get(compilerClass);
+		compilerExecutor.shutdown();
+	}catch (e){
+		print(e);
+		if("javaException" in e){
+			e.javaException.printStackTrace();
+		}
+	}
+}
 
 var
 	console = new java.io.BufferedReader(new java.io.InputStreamReader(java.lang.System["in"])),
@@ -169,4 +183,8 @@ while(1){
 		exception = ". OPTIMIZER FAILED: " + e;
 	}
 	print("Done (compile time:" + ((new Date()).getTime()-start)/1000 + "s)" + exception);
+}
+
+if (jscomp) {
+	shutdownClosureExecutorService();
 }


### PR DESCRIPTION
https://bugs.dojotoolkit.org/ticket/17105

https://github.com/google/closure-compiler/blob/v20120917/src/com/google/javascript/jscomp/Compiler.java#L194

Use Java reflection to call ExecutorService.shutdown() on Compiler's
`compilerExecutor` field when we are finished compiling JS.

This prevents the default 60 seconds timeout that the ExecutorService will
wait before stopping Threads that have no work to do.

WARNING - This code uses the private `compilerExecutor` field of Compiler,
and so may break if Compiler's internal implementation changes.