### PR TITLE
Compile to ECMASCRIPT5 when using closure compiler

### DIFF
--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -104,6 +104,13 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 	//Set up options
 	var options = new jscomp.CompilerOptions();
 	for(var k in optimizeOptions){
+
+		// some options need to pass as funtion argument
+		if (k === 'languageIn') {
+			options.setLanguageIn(jscomp.CompilerOptions.LanguageMode[optimizeOptions[k]]);
+			continue;
+		}
+
 		options[k] = optimizeOptions[k];
 	}
 	// Must have non-null path to trigger source map generation, also fix version


### PR DESCRIPTION
fix this https://bugs.dojotoolkit.org/ticket/16601, a bug 3 years ago.

the ticket above mark as a duplicate of https://bugs.dojotoolkit.org/ticket/16196, but this not right, if we write the `optimizeOptions` as

```
optimizeOptions: {
    languangeIn: 'ECMASCRIPT5',
},
```

then closure will throw an error 

```
Done (compile time:0.098s). OPTIMIZER FAILED: InternalError: Java class "com.google.javascript.jscomp.CompilerOptions" has no public instance field or method named "languangeIn".
```

because this how dojo-util create the closure option object with this

```
	var options = new jscomp.CompilerOptions();
	for(var k in optimizeOptions){
		options[k] = optimizeOptions[k];
	}
```

the closure docs http://javadoc.closure-compiler.googlecode.com/git/com/google/javascript/jscomp/CompilerOptions.html#setLanguageIn%28com.google.javascript.jscomp.CompilerOptions.LanguageMode%29 says it should be call `setLanguageIn()`, and pass a typed-object to it. There noway to do this in optimizeOptions.

We don't need to find a new way to pass the option, because the dojo have code not compatible with ES3 now (at lease at v1.10), it can not complie to ES3

```
dojo.js.uncompressed.js:2033: ERROR - Parse error. IE8 (and below) will parse trailing commas in array and object literals incorrectly. If you are targeting newer versions of JS, set the appropriate language_in option.
    'dojo/aspect',
    ^    

dojo.js.uncompressed.js:85075: ERROR - Parse error. missing name after . operator
                return this.transformer.in(value);
                                        ^

dojo.js.uncompressed.js:94967: ERROR - Parse error. invalid property id
                var widget=new BorderContainer({gutters:false, class:"singleDecorator"});
                                                               ^

3 error(s), 0 warning(s)
Done (compile time:0.938s)
```

So, ES5 is only option.