### PR TITLE
Use util/build/fs in copy transform

### DIFF
--- a/build/node/fs.js
+++ b/build/node/fs.js
@@ -7,6 +7,17 @@ define(["../fileHandleThrottle"], function(fht){
 		writeFileSync:fs.writeFileSync,
 		readdirSync:fs.readdirSync,
 
+		copyFile:function(src, dest, cb){
+			// Use no encoding, as the file may be text or binary.
+			fs.readFile(src, undefined, function(err, contents) {
+				if (err) {
+					cb(err);
+				} else {
+					fs.writeFile(dest, contents, undefined, cb);
+				}
+			});
+		},
+
 		readFile:function(filename, encoding, cb){
 			fht.enqueue(function(){
 				fs.readFile(filename, encoding, function(code){

--- a/build/rhino/fs.js
+++ b/build/rhino/fs.js
@@ -1,5 +1,36 @@
 define([], function() {
 	var
+		copyFile = function(src, dest, cb) {
+			function close(it) {
+				try{
+					if (it) it.close();
+				}catch(e){
+					// swallow
+				}
+			}
+			var BUF_SIZE = 8192;
+			var fis = null;
+			var fos = null;
+			try {
+				fis = new java.io.FileInputStream(src);
+				fos = new java.io.FileOutputStream(dest);
+
+				var buf = java.lang.reflect.Array.newInstance(java.lang.Byte.TYPE, BUF_SIZE);
+
+				var i;
+				while ((i = fis.read(buf)) != -1) {
+					fos.write(buf, 0, i);
+				}
+			}finally{
+				close(fis);
+				close(fos);
+			}
+			// invoke callback if no error.
+			if (cb) {
+				cb(0);
+			}
+		},
+
 		readFileSync = function(filename, encoding) {
 			if (encoding=="utf8") {
 				// convert node.js idiom to rhino idiom
@@ -31,6 +62,8 @@ define([], function() {
 		};
 
 	return {
+		copyFile:copyFile,
+
 		statSync:function(filename) {
 			return new java.io.File(filename);
 		},

--- a/build/transforms/copy.js
+++ b/build/transforms/copy.js
@@ -2,8 +2,18 @@ define([
 	"../buildControl",
 	"../process",
 	"../fileUtils",
+	"../fs",
 	"dojo/has"
-], function(bc, process, fileUtils, has) {
+], function(bc, process, fileUtils, fs, has) {
+
+	function copyFileWithFs(src, dest, cb) {
+		if (has("is-windows")) {
+			src = fileUtils.normalize(src);
+			dest = fileUtils.normalize(dest);
+		}
+		fs.copyFile(src, dest, cb);
+	}
+
 	return function(resource, callback) {
 		fileUtils.ensureDirectoryByFilename(resource.dest);
 		var
@@ -14,6 +24,12 @@ define([
 			args = has("is-windows") ?
 				["cmd", "/c", "copy", fileUtils.normalize(resource.src), fileUtils.normalize(resource.dest), errorMessage, bc, cb] :
 				["cp", resource.src, resource.dest, errorMessage, bc, cb];
+
+		if (bc.useFsCopy) {
+			copyFileWithFs(resource.src, resource.dest, cb);
+			return callback;
+		}
+
 		process.exec.apply(process, args);
 		return callback;
 	};


### PR DESCRIPTION
@wkeese - I've rebased the branch that we commented on (https://github.com/gitgrimbo/util/commit/5a808a42781ba1b4c0a9ae5256b1120a4d313e05) so any subsequent merge is simpler.

Some performance measurements are listed here - https://gist.github.com/gitgrimbo/950f3301ce7b9d8ce18f.  From my own testing, using either Node or Java to perform the file copying was significantly faster than using a command-spawning approach (https://github.com/dojo/util/blob/1.10.4/build/transforms/copy.js#L14-L17).  The improvement seemed even more marked when there was involvement from anti-virus software.

Ideally there should be some more testing for this, but it seems ok from my own experiments. As such, I have left this feature as optional and activated by a boolean build config property, `useFsCopy`.
