### PR TITLE
html runner now supports specifing .html tests in url

### DIFF
--- a/doh/_parseURLargs.js
+++ b/doh/_parseURLargs.js
@@ -162,15 +162,7 @@
 
 			deps: ["dohDojo/domReady", "doh"],
 
-			callback: function(domReady, doh){
-				domReady(function(){
-					doh._fixHeight();
-					doh.breakOnError= breakOnError;
-					require(test, function(){
-						doh.run();
-					});
-				});
-			},
+			callback: callback,
 
 			async: async
 		};
@@ -190,18 +182,28 @@
 				'dojox'
 			],
 			deps: ["dojo/domReady", "doh/main"],
-			callback: function(domReady, doh){
-				domReady(function(){
-					doh._fixHeight();
-					doh.breakOnError= breakOnError;
-					require(test, function(){
-						doh.run();
-					});
-				});
-			},
+			callback: callback,
 			async: async,
 			isDebug: 1
 		};
+	}
+	
+	function callback(domReady, doh){
+		domReady(function(){
+			doh._fixHeight();
+			doh.breakOnError= breakOnError;
+			for (var amdTests = [], i = 0, l = test.length; i < l; i++) {
+				var module = test[i];
+				if(/\.html$/.test(module)){
+					doh.register(module, require.toUrl(module), 999999);
+				}else{
+					amdTests.push(module);
+				}
+			}
+			require(amdTests, function(){
+				doh.run();
+			});
+		});
 	}
 	
 	// load all of the dohPlugins

--- a/doh/_parseURLargs.js
+++ b/doh/_parseURLargs.js
@@ -190,10 +190,11 @@
 	
 	function callback(domReady, doh){
 		domReady(function(){
+			var amdTests = [], module;
 			doh._fixHeight();
 			doh.breakOnError= breakOnError;
-			for (var amdTests = [], i = 0, l = test.length; i < l; i++) {
-				var module = test[i];
+			for (var i = 0, l = test.length; i < l; i++) {
+				module = test[i];
 				if(/\.html$/.test(module)){
 					doh.register(module, require.toUrl(module), 999999);
 				}else{


### PR DESCRIPTION
This PR modifies doh html runner, so it supports opening tests written as .html, e.g.:

util/doh/runner.html?test=dijit/tests/Menu.html,dojox/lang/tests/array,dijit/tests/Destroyable.html