### PR TITLE
changed context from 'this' to 'doh' in the part of the retEnd function

### DIFF
--- a/doh/runner.js
+++ b/doh/runner.js
@@ -1393,7 +1393,7 @@ doh._runRegFixture = function(/*String*/ groupName, /*Object*/ fixture){
 				try {
 					fixture.tearDown(doh);
 				}catch(e){
-					this.debug("Error tearing down test: "+e.message);
+					doh.debug("Error tearing down test: "+e.message);
 				}
 			}
 			tg.inFlight--;
@@ -1582,7 +1582,7 @@ doh.pause = function(){
 doh.run = function(){
 	// summary:
 	//		begins or resumes the test process.
-	
+
 	this._paused = false;
 	var cg = this._currentGroup;
 	var ct = this._currentTest;


### PR DESCRIPTION
changed context from 'this' to 'doh' in the part of the retEnd function that is handling the case where the tearDown method throws an exception