### PR TITLE
Fixes 18868 - Hardcoded './util/…' paths in dojo-util break when installed via npm

### DIFF
--- a/doh/_parseURLargs.js
+++ b/doh/_parseURLargs.js
@@ -20,28 +20,28 @@
 			//
 			["dojo/tests/module"],
 
-		paths = 
-			// zero to many path items to pass to the AMD loader; provided by semicolon separated values 
+		paths =
+			// zero to many path items to pass to the AMD loader; provided by semicolon separated values
 			// for URL query parameter="paths"; each path item has the form <from-path>,<to-path>
 			// i.e. path-to-util/doh/runner.html?paths=my/from/path,my/to/path;my/from/path2,my/to/path2
 			{},
-			
-		dohPlugins = 
+
+		dohPlugins =
 			// Semicolon separated list of files to load before the tests.
 			// Idea is to override aspects of DOH for reporting purposes.
 			"",
 
-		breakOnError = 
+		breakOnError =
 			// boolean; instructs doh to call the debugger upon a test failures; this can be helpful when
 			// trying to isolate exactly where the test failed
 			false,
 
-		async = 
+		async =
 			// boolean; config require.async==true before loading boot; this will have the effect of making
 			// version 1.7+ dojo bootstrap/loader operating in async mode
 			false,
 
-		sandbox = 
+		sandbox =
 			// boolean; use a loader configuration that sandboxes the dojo and dojox objects used by doh
 			false,
 
@@ -52,9 +52,10 @@
 				}
 				return result;
 			}else{
-				return text.match(/[^\s]*/)[0]; 
+				return text.match(/[^\s]*/)[0];
 			}
-		};
+		},
+		packages= [];
 
 		qstr = window.location.search.substr(1);
 
@@ -108,6 +109,17 @@
 				case "dohPlugins":
 					dohPlugins=value.split(";");
 					break;
+				case 'mapPackage':
+					var packagesRaw=value.split(';');
+					for (var i = 0; i < packagesRaw.length; i++) {
+						var parts = packagesRaw[i].split(',');
+						packages.push({
+							name: parts[0],
+							location: parts[1]
+						});
+					}
+
+					break;
 			}
 		}
 	}
@@ -136,7 +148,7 @@
 				// and dojox uses dojo...that is, dohDojox...which must be mapped to dohDojo in the context of dohDojox
 				packageMap: {dojo: "dohDojo", dojox: "dohDojox"}
 			}],
-			
+
 			// next, we need to preposition a special configuration for dohDojo
 			cache: {
 				"dohDojo*_base/config": function(){
@@ -187,7 +199,21 @@
 			isDebug: 1
 		};
 	}
-	
+
+	for (var i = 0; i < packages.length; i++) {
+		var isFound = false;
+		for (var j = 0; j < config.packages.length; j++) {
+			if (packages[i].name == config.packages[j].name) {
+				isFound = true;
+				config.packages[j].location = packages[i].location;
+				break;
+			}
+		}
+		if (!isFound) {
+			config.packages.push(packages[i]);
+		}
+	}
+
 	function callback(domReady, doh){
 		domReady(function(){
 			var amdTests = [], module;
@@ -206,7 +232,7 @@
 			});
 		});
 	}
-	
+
 	// load all of the dohPlugins
 	if(dohPlugins){
 		var i = 0;
@@ -214,7 +240,7 @@
 			config.deps.push(dohPlugins[i]);
 		}
 	}
-	
+
 	require = config;
 
 	// now script inject any boots


### PR DESCRIPTION
add ability to pass 'mapPackage' parameter on the command line to add or override a package definition when invoking dojo (e.g. running the build system.

There are three use cases that have been considered:

1. Executing Dojo builds
1. Executing DOH tests using the command line
1. Executing DOH tests with the browser runner

This PR is intended to address the third use cases. It can't however, completely address it. Any references to the DOH package in the HTML test files will have to be mapped via that page's dojoConfig.

This PR adds the ability to pass a new query parameter "mapPackage" in the test URL to dynamically remap packages. The argument needs to be of the form "name1,value1;name2,value2" where "name" is the value to be passed in the packages "name" field and "location" maps to the packages location, relative to the runner.html page.