### PR TITLE
Fixes #18919 - New version of closure compiler breaks builds

### DIFF
--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -243,6 +243,10 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 	// File name and associated map name
 	var mapTag = useSourceMaps ? ("\n//# sourceMappingURL=" + destFilename + ".map") : "",
 		compiler = new Packages.com.google.javascript.jscomp.Compiler(Packages.java.lang.System.err);
+
+	// force this option to false to prevent overly agressive code elimination (#18919)
+	options.setDeadAssignmentElimination(false);
+
 	compiler.compile(externSourceFile, jsSourceFile, options);
 	writeFile(dest, copyright + built + compiler.toSource() + mapTag, "utf-8");
 

--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -258,7 +258,6 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 		var sb = new java.lang.StringBuffer();
 		sourceMap.appendTo(sb, destFilename);
 		writeFile(dest + ".map", sb.toString(), "utf-8");
-		writeFile("options.txt", options);
 	}
 }
 

--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -106,6 +106,23 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 	var options = new jscomp.CompilerOptions();
 	var set;
 
+	// Set the closure optimization level, use simple optimizations by default
+	var FLAG_compilation_level = jscomp.CompilationLevel.SIMPLE_OPTIMIZATIONS;
+	if (optimizeOptions.compilationLevel) {
+		switch (optimizeOptions.compilationLevel.toUpperCase()) {
+			case "WHITESPACE_ONLY": FLAG_compilation_level = jscomp.CompilationLevel.WHITESPACE_ONLY;
+				break;
+			case "SIMPLE_OPTIMIZATIONS": FLAG_compilation_level = jscomp.CompilationLevel.SIMPLE_OPTIMIZATIONS;
+				break;
+			case "ADVANCED_OPTIMIZATIONS": FLAG_compilation_level = jscomp.CompilationLevel.ADVANCED_OPTIMIZATIONS;
+				break;
+		}
+	}
+
+	FLAG_compilation_level.setOptionsForCompilationLevel(options);
+	var FLAG_warning_level = jscomp.WarningLevel.DEFAULT;
+	FLAG_warning_level.setOptionsForWarningLevel(options);
+
 	for(var k in optimizeOptions){
 		// Skip compilation level option
 		if (k === 'compilationLevel') {
@@ -219,22 +236,7 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 		options.prettyPrint = true;
 	}
 
-	// Set the closure optimization level, use simple optimizations by default
-	var FLAG_compilation_level = jscomp.CompilationLevel.SIMPLE_OPTIMIZATIONS;
-	if (optimizeOptions.compilationLevel) {
-		switch (optimizeOptions.compilationLevel.toUpperCase()) {
-			case "WHITESPACE_ONLY": FLAG_compilation_level = jscomp.CompilationLevel.WHITESPACE_ONLY;
-				break;
-			case "SIMPLE_OPTIMIZATIONS": FLAG_compilation_level = jscomp.CompilationLevel.SIMPLE_OPTIMIZATIONS;
-				break;
-			case "ADVANCED_OPTIMIZATIONS": FLAG_compilation_level = jscomp.CompilationLevel.ADVANCED_OPTIMIZATIONS;
-				break;
-		}
-	}
 
-	FLAG_compilation_level.setOptionsForCompilationLevel(options);
-	var FLAG_warning_level = jscomp.WarningLevel.DEFAULT;
-	FLAG_warning_level.setOptionsForWarningLevel(options);
 
 	//Prevent too-verbose logging output
 	Packages.com.google.javascript.jscomp.Compiler.setLoggingLevel(java.util.logging.Level.SEVERE);
@@ -256,6 +258,7 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 		var sb = new java.lang.StringBuffer();
 		sourceMap.appendTo(sb, destFilename);
 		writeFile(dest + ".map", sb.toString(), "utf-8");
+		writeFile("options.txt", options);
 	}
 }
 


### PR DESCRIPTION
This PR was originally intended to revert a008758314572cb17fab19a0ab286c5f4fd4e9b0, but further research has shown that the options "deadAssignmentElmination" was causing the issues observed in [18919](https://bugs.dojotoolkit.org/ticket/18919). This PR has been updated to force this setting to false in order to eliminate the issue.

Original Description: 
Revert change to update version of Google Closure Compiler due to optimizations causing builds to break.

This reverts commit a008758314572cb17fab19a0ab286c5f4fd4e9b0.