### PR TITLE
Fixes 18919 - Java-driven builds fail with new closure compiler

### DIFF
--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -123,6 +123,9 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 	var FLAG_warning_level = jscomp.WarningLevel.DEFAULT;
 	FLAG_warning_level.setOptionsForWarningLevel(options);
 
+	// force this option to false to prevent overly agressive code elimination (#18919)
+	options.setDeadAssignmentElimination(false);
+
 	for(var k in optimizeOptions){
 		// Skip compilation level option
 		if (k === 'compilationLevel') {
@@ -236,8 +239,6 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 		options.prettyPrint = true;
 	}
 
-
-
 	//Prevent too-verbose logging output
 	Packages.com.google.javascript.jscomp.Compiler.setLoggingLevel(java.util.logging.Level.SEVERE);
 
@@ -246,8 +247,6 @@ function ccompile(src, dest, optimizeSwitch, copyright, optimizeOptions, useSour
 	var mapTag = useSourceMaps ? ("\n//# sourceMappingURL=" + destFilename + ".map") : "",
 		compiler = new Packages.com.google.javascript.jscomp.Compiler(Packages.java.lang.System.err);
 
-	// force this option to false to prevent overly agressive code elimination (#18919)
-	options.setDeadAssignmentElimination(false);
 
 	compiler.compile(externSourceFile, jsSourceFile, options);
 	writeFile(dest, copyright + built + compiler.toSource() + mapTag, "utf-8");

--- a/build/transforms/optimizer/closure.js
+++ b/build/transforms/optimizer/closure.js
@@ -52,6 +52,15 @@ define([
 
 			//Set up options
 			var options = new jscomp.CompilerOptions();
+
+			var FLAG_compilation_level = jscomp.CompilationLevel.SIMPLE_OPTIMIZATIONS;
+			FLAG_compilation_level.setOptionsForCompilationLevel(options);
+			var FLAG_warning_level = jscomp.WarningLevel.DEFAULT;
+			FLAG_warning_level.setOptionsForWarningLevel(options);
+
+			// force this option to false to prevent overly agressive code elimination (#18919)
+			options.setDeadAssignmentElimination(false);
+
 			for(var k in bc.optimizeOptions){
 				// some options need to pass as funtion argument
 				if (k === 'languageIn') {
@@ -66,10 +75,7 @@ define([
 			if(optimizeSwitch.indexOf(".keeplines") !== -1){
 				options.prettyPrint = true;
 			}
-			var FLAG_compilation_level = jscomp.CompilationLevel.SIMPLE_OPTIMIZATIONS;
-			FLAG_compilation_level.setOptionsForCompilationLevel(options);
-			var FLAG_warning_level = jscomp.WarningLevel.DEFAULT;
-			FLAG_warning_level.setOptionsForWarningLevel(options);
+
 
 			//Prevent too-verbose logging output
 			Packages.com.google.javascript.jscomp.Compiler.setLoggingLevel(java.util.logging.Level.SEVERE);


### PR DESCRIPTION
* updated closure.js to implement the same fix as was added to optimizeRunner.js to fix Java-driven builds

* moved setting of deadAssignmentElimination to be above application of  settings from build profile to allow user to override, if they desire