### PR TITLE
Fix Java build failure when optimizeOptions not provided in profile

### DIFF
--- a/build/transforms/optimizer/closure.js
+++ b/build/transforms/optimizer/closure.js
@@ -52,7 +52,7 @@ define([
 
 			//Set up options
 			var options = new jscomp.CompilerOptions();
-			var optimizeOptions = bc.optimizeOptions;
+			var optimizeOptions = bc.optimizeOptions || {};
 
 			var FLAG_compilation_level = jscomp.CompilationLevel.SIMPLE_OPTIMIZATIONS;
 			if (optimizeOptions.compilationLevel) {


### PR DESCRIPTION
add handling for java build with closure compiler when optimizeOptions object is not defined in build profile