### PR TITLE
Fixes #19025, optimizeRunner.js catches IllegalArgumentException in shutdownClosureExecutorService

### DIFF
--- a/build/optimizeRunner.js
+++ b/build/optimizeRunner.js
@@ -266,6 +266,10 @@ function shutdownClosureExecutorService(){
 		var compilerExecutorField = compilerClass.getDeclaredField("compilerExecutor");
 		compilerExecutorField.setAccessible(true);
 		var compilerExecutor = compilerExecutorField.get(compiler);
+		compilerClass = compilerExecutor.getClass();
+		compilerExecutorField = compilerClass.getDeclaredField("compilerExecutor");
+		compilerExecutorField.setAccessible(true);
+		compilerExecutor = compilerExecutorField.get(compilerExecutor);
 		compilerExecutor.shutdown();
 	}catch (e){
 		print(e);


### PR DESCRIPTION
The https://github.com/dojo/util/commit/d81fb9e35b1a089a0e81c24ce73c4f16d6754842 commit does not eliminate an exception being thrown by the `shutdownClosureExecutorService()` function. Now it simply throws another exception.

The deal is, the `shutdown()` method is defined on `private static ExecutorService com.google.javascript.jscomp.Compiler.compilerExecutor.compilerExecutor`.

Thus, the correct function body for the `shutdownClosureExecutorService()` function should be as follows:

```javascript
function shutdownClosureExecutorService(){
	try{
		var compilerClass = java.lang.Class.forName("com.google.javascript.jscomp.Compiler");
		var compilerExecutorField = compilerClass.getDeclaredField("compilerExecutor");
		compilerExecutorField.setAccessible(true);
		var compilerExecutor = compilerExecutorField.get(compiler);
		compilerClass = compilerExecutor.getClass();
		compilerExecutorField = compilerClass.getDeclaredField("compilerExecutor");
		compilerExecutorField.setAccessible(true);
		compilerExecutor = compilerExecutorField.get(compilerExecutor);
		compilerExecutor.shutdown();
	}catch (e){
		print(e);
		if("javaException" in e){
			e.javaException.printStackTrace();
		}
	}
}
```

Also, when we move to a newer version of the Google Closure Compiler, one newer than https://github.com/google/closure-compiler/commit/7bdbe963715ade06047c247065e43170933cf5e1, the whole `shutdownClosureExecutorService()` function becomes obsolete, as they shutting down the executor service by themselves from there on, if I understand correctly.