### PR TITLE
Fix for field aliases that appear outside of calendars in CLDR root.xml

### DIFF
--- a/buildscripts/cldr/alias.js
+++ b/buildscripts/cldr/alias.js
@@ -94,6 +94,10 @@ function _calculateAliasPath(bundle, name/*String*/){
 				mapping[LOCALE_ALIAS_SOURCE_PROPERTY] = src;
 				mapping[LOCALE_ALIAS_TARGET_PROPERTY] = bundle[localeAliasSource + LOCALE_ALIAS_MARK + i][LOCALE_ALIAS_TARGET_PROPERTY];
 				mapping[LOCALE_ALIAS_TARGET_BUNDLE] = bundle[localeAliasSource + LOCALE_ALIAS_MARK + i][LOCALE_ALIAS_TARGET_BUNDLE];
+				if (!mapping[LOCALE_ALIAS_TARGET_BUNDLE]) {
+					// TODO: Fix calendar.xsl to handle the new aliases in root.xml
+					continue;
+				}
 				//whether aliased to the bundle itself
 				mapping.inSelf = mapping[LOCALE_ALIAS_TARGET_BUNDLE] === name;
 				path.push(mapping);


### PR DESCRIPTION
The updated root.xml file (CLDR version 30) has field aliases that did not appear in the previous version. These do not appear within calendars and may need to be adjusted to appear within all calendars if we do a more formal update to CLDR data. This fix enables the build to complete when field aliases appear outside of a calendar.