### PR TITLE
Ignore the newly added CLDR minimumGroupingDigits

### DIFF
--- a/buildscripts/cldr/number.xsl
+++ b/buildscripts/cldr/number.xsl
@@ -181,7 +181,7 @@
       </xsl:choose>
 </xsl:template>
 
-<xsl:template name="ignore" match="defaultNumberingSystem | otherNumberingSystems | currencies | miscPatterns"></xsl:template>
+<xsl:template name="ignore" match="defaultNumberingSystem | otherNumberingSystems | currencies | miscPatterns | minimumGroupingDigits"></xsl:template>
 
   <!-- too bad that can only use standard xsl:call-template(name can not be variable) 
          error occurs if use <saxson:call-templates($templateToCall)  /> -->


### PR DESCRIPTION
This data type is not used in previous CLDR builds and does not have a mapping to handle it.