### PR TITLE
Use callback format with provided global

### DIFF
--- a/build/transforms/writeDojo.js
+++ b/build/transforms/writeDojo.js
@@ -12,7 +12,7 @@ define([
 		var
 			getUserConfig = function(){
 				if(!bc.userConfig){
-					return "this.dojoConfig || this.djConfig || this.require || {}";
+					return "function(global){ return global.dojoConfig || global.djConfig || global.require || {}; }";
 				}
 				if(typeof bc.userConfig == "string"){
 					return bc.userConfig;


### PR DESCRIPTION
As part of [#270](https://github.com/dojo/dojo/pull/270), using the global variable with strict mode and CSP `unsafe-eval` enforced means we need to retrieve the global object manually. `dojo.js` has been updated to retrieve this object and supports a function callback to its first argument to which it will pass this global object.