### PR TITLE
Modifications for release process

### DIFF
--- a/buildscripts/build_release.sh
+++ b/buildscripts/build_release.sh
@@ -3,7 +3,7 @@
 set -e
 
 usage() {
-	echo "Usage: $0 [-c] [-b branch] version"
+	echo "Usage: $0 [-c] [-t] [-b branch] version"
 	echo
 	echo "-b  Branch to archive. Defaults to 'master'."
 	echo "-t  Include themes repo in release."


### PR DESCRIPTION
This should do the following:

- eliminate $USERNAME, which isn't used for anything other than stopping the release process for _reasons_
- Shuffles upload behaviors to post-processing and to the appropriate directories
- finalizes everything from our latest experiences with the 1.14 release!

Edit:

- Release build is confirmed to work on Debian 9 & Java 1.8 (upgrade from previous server)