### PR TITLE
Fix uglify use with newer node versions

### DIFF
--- a/build/transforms/optimizer/uglify_worker.js
+++ b/build/transforms/optimizer/uglify_worker.js
@@ -36,7 +36,7 @@ function factory(uglify, fs){
 
 			if (useSourceMaps) {
 				output += "//# sourceMappingURL=" + dest.split("/").pop() + ".map";
-				fs.writeFile(dest + ".map", gen_options.source_map.toString(), "utf-8");
+				fs.writeFile(dest + ".map", gen_options.source_map.toString(), "utf-8", function() {});
 			}
 
 			return output;


### PR DESCRIPTION
Recent versions of node enforce the callback argument to writeFile or fail with errors like:
```
error(356) The optimizer threw an exception; the module probably contains syntax errors. module identifier: dojo/dojo; exception: TypeError [ERR_INVALID_CALLBACK]: Callback must be a function TypeError [ERR_INVALID_CALLBACK]: Callback must be a function
```
Deal with this by explicitly providing a callback.