### PR TITLE
buildControl: set default values for Closure languageIn/languageOut

### DIFF
--- a/build/buildControl.js
+++ b/build/buildControl.js
@@ -547,6 +547,11 @@ define([
 	bc.optimize = fixupOptimize(bc.optimize);
 	bc.layerOptimize = fixupOptimize(bc.layerOptimize);
 
+	if(/closure/.test(bc.optimize) || /closure/.test(bc.layerOptimize)){
+		bc.optimizeOptions = bc.optimizeOptions || {};
+		bc.optimizeOptions.languageOut = bc.optimizeOptions.languageOut || 'NO_TRANSPILE';
+	}
+
 	(function(){
 		var fixedScopeMap = {dojo:"dojo", dijit:"dijit", dojox:"dojox"};
 		(bc.scopeMap || []).forEach(function(pair){

--- a/build/buildControl.js
+++ b/build/buildControl.js
@@ -549,7 +549,10 @@ define([
 
 	if(/closure/.test(bc.optimize) || /closure/.test(bc.layerOptimize)){
 		bc.optimizeOptions = bc.optimizeOptions || {};
-		bc.optimizeOptions.languageIn = bc.optimizeOptions.languageIn || 'ECMASCRIPT3';
+		// ECMASCRIPT_2017 is necessary to avoid throwing errors on block-scoped functions
+		// https://github.com/google/closure-compiler/issues/3189
+		bc.optimizeOptions.languageIn = bc.optimizeOptions.languageIn || 'ECMASCRIPT_2017';
+		// ECMASCRIPT3 is necessary to preserve compatibility with older browsers/JS runtimes
 		bc.optimizeOptions.languageOut = bc.optimizeOptions.languageOut || 'ECMASCRIPT3';
 	}
 

--- a/build/buildControl.js
+++ b/build/buildControl.js
@@ -549,7 +549,8 @@ define([
 
 	if(/closure/.test(bc.optimize) || /closure/.test(bc.layerOptimize)){
 		bc.optimizeOptions = bc.optimizeOptions || {};
-		bc.optimizeOptions.languageOut = bc.optimizeOptions.languageOut || 'NO_TRANSPILE';
+		bc.optimizeOptions.languageIn = bc.optimizeOptions.languageIn || 'ECMASCRIPT3';
+		bc.optimizeOptions.languageOut = bc.optimizeOptions.languageOut || 'ECMASCRIPT3';
 	}
 
 	(function(){


### PR DESCRIPTION
The Google Closure Compiler has a default language output setting that may change by release. [v20170806](https://github.com/google/closure-compiler/wiki/Releases#august-6-2017-v20170806) changed the default output language to ECMASCRIPT5.

This PR adds a default values for `languageIn` (ECMASCRIPT_2017) and `languageOut` (ECMASCRIPT3) if the build tool is configured to use the Google Closure Compiler. These can be overridden in `optimizeOptions` in the build profile.

ECMASCRIPT_2017 is used for `languageIn` to allow existing code to continue working. With the addition of block scope in ES6 the Google Closure Compiler treats block-scoped functions as errors in pre-ES6 code.

Fixes #81