### PR TITLE
demos-all.profile: remove references to non-existent demos

### DIFF
--- a/buildscripts/profiles/demos-all.profile.js
+++ b/buildscripts/profiles/demos-all.profile.js
@@ -115,20 +115,6 @@ dependencies = {
 			]
 		},
 		{
-			// the Survey demo
-			name: "../demos/survey/src.js",
-			dependencies:[
-				"demos.survey.src"
-			]
-		},
-		{
-			// the BabelChat demo
-			name: "../demos/babelChat/src.js",
-			dependencies:[
-				"demos.babelChat.src"
-			]
-		},
-		{
 			name: "../demos/faces/src.js",
 			dependencies:[
 				"demos.faces.src"


### PR DESCRIPTION
The BabelChat and Survey demos were removed from `dojo/demos` in [6267faf](https://github.com/dojo/demos/commit/6267fafa905120cebdbb3644eef7c569ba2a6565)