### PR TITLE
fix dojo default doh test path from /tests to /testDOH

### DIFF
--- a/doh/_parseURLargs.js
+++ b/doh/_parseURLargs.js
@@ -18,7 +18,7 @@
 			//	 * the AMD module doh/selfTest
 			//	 * the plain old Javascript resource my/path/test.js
 			//
-			["dojo/tests/module"],
+			["dojo/testsDOH/module"],
 
 		paths =
 			// zero to many path items to pass to the AMD loader; provided by semicolon separated values


### PR DESCRIPTION
fix dojo default doh test path from /tests to /testDOH as no module.js in dojo/tests