### PR TITLE
fix dojo default doh test path from /tests to /testsDOH

### DIFF
--- a/doh/_parseURLargs.js
+++ b/doh/_parseURLargs.js
@@ -9,6 +9,7 @@
 
 		test =
 			// zero to many AMD modules and/or URLs to load; provided by csv URL query parameter="test"
+			// the default doh module is dojo/testsDOH/module
 			// For example, the URL...
 			//
 			//		 path-to-util/doh/runner.html?test=doh/selfTest,my/path/test.js
@@ -18,7 +19,7 @@
 			//	 * the AMD module doh/selfTest
 			//	 * the plain old Javascript resource my/path/test.js
 			//
-			["dojo/tests/module"],
+			["dojo/testsDOH/module"],
 
 		paths =
 			// zero to many path items to pass to the AMD loader; provided by semicolon separated values


### PR DESCRIPTION
fix dojo default doh test path from /tests to /testsDOH as no module.js in dojo/tests